### PR TITLE
Rebrand to HNM Devs and fix editor import

### DIFF
--- a/src/pages/[roadmapId]/projects.astro
+++ b/src/pages/[roadmapId]/projects.astro
@@ -8,7 +8,7 @@ import { getOpenGraphImageUrl } from '../../lib/open-graph';
 import { type RoadmapFrontmatter, getRoadmapIds } from '../../lib/roadmap';
 import { projectApi } from '../../api/project';
 
-export const prerender = true;
+export const prerender = false;
 
 export async function getStaticPaths() {
   const roadmapIds = await getRoadmapIds();


### PR DESCRIPTION
Rebrand to HNM Devs and fix Vercel deployment by resolving the missing local editor package.

The Vercel build failed because the `@roadmapsh/editor` workspace package was not committed due to a `.gitignore` entry. This PR creates the necessary stub package files, removes the `.gitignore` exclusion, and adjusts Vite configuration to correctly resolve the local package imports, ensuring successful builds and deployment.

---

[Open in Web](https://www.cursor.com/agents?id=bc-6fda139e-b22c-4f99-92a2-1d1d1670a5be) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-6fda139e-b22c-4f99-92a2-1d1d1670a5be)